### PR TITLE
fix: remove `always()` on commit step

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -32,7 +32,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
     - uses: dawidd6/action-git-user-config@v1
-      if: github.ref == 'refs/heads/main' && always()
+      if: github.ref == 'refs/heads/main'
     - name: merge main to alpha
       if: github.ref == 'refs/heads/main' && inputs.merge-to-alpha == 'true'
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -34,7 +34,7 @@ runs:
     - uses: dawidd6/action-git-user-config@v1
       if: github.ref == 'main' && always()
     - name: merge main to alpha
-      if: github.ref == 'main' && inputs.merge-to-alpha == 'true' && always()
+      if: github.ref == 'main' && inputs.merge-to-alpha == 'true'
       shell: bash
       run: |
         git pull


### PR DESCRIPTION
there is a scenario where semantic-release can fail and subsequent runs of this composite action won't finalize release due to the merge commit already happening. specifically, when semantic-release fails in between having created a commit and git tag, but before it creates the github release. this causes semantic-release to not create a release because the source branch is ahead of main.